### PR TITLE
New endpoint for processing config updates from projects

### DIFF
--- a/lib/txgh/app.rb
+++ b/lib/txgh/app.rb
@@ -100,6 +100,28 @@ module Txgh
       end
     end
 
+    post '/project' do
+      settings.logger.info('Processing request at /hooks/project')
+
+      project = params[:project]
+      config = Txgh::KeyManager.config_from_project(project)
+
+      if authenticated_transifex_request?(config.transifex_project, request)
+        new_config = params[:new_config]
+
+        handler = transifex_project_handler_for(
+          project: config.transifex_project,
+          new_config: new_config,
+          logger: settings.logger
+        )
+
+        handler.execute
+        status 200
+      else
+        status 401
+      end
+    end
+
     private
 
     def authenticated_github_request?(repo, request)
@@ -128,6 +150,10 @@ module Txgh
 
     def github_handler_for(options)
       Txgh::Handlers::GithubHookHandler.new(options)
+    end
+
+    def transifex_project_handler_for(options)
+      Txgh::Handlers::TransifexProjectHookHandler.new(options)
     end
   end
 end

--- a/lib/txgh/handlers.rb
+++ b/lib/txgh/handlers.rb
@@ -2,5 +2,6 @@ module Txgh
   module Handlers
     autoload :GithubHookHandler,    'txgh/handlers/github_hook_handler'
     autoload :TransifexHookHandler, 'txgh/handlers/transifex_hook_handler'
+    autoload :TransifexProjectHookHandler, 'txgh/handlers/transifex_project_hook_handler'
   end
 end

--- a/lib/txgh/handlers/transifex_project_hook_handler.rb
+++ b/lib/txgh/handlers/transifex_project_hook_handler.rb
@@ -1,0 +1,30 @@
+require 'logger'
+
+module Txgh
+  module Handlers
+    class TransifexProjectHookHandler
+      attr_reader :project, :new_config, :logger
+
+      def initialize(options = {})
+        @project = options.fetch(:project)
+        @new_config = options.fetch(:new_config)
+        @logger = options.fetch(:logger) { Logger.new(STDOUT) }
+      end
+
+      def execute
+        logger.info("Processing config update for #{project.name}")
+
+        project_config_file_path = project.config['tx_config']
+        project_config = ParseConfig.load(new_config)
+
+        logger.info("Writing new configuration to #{project_config_file_path}")
+
+        File.open(project_config_file_path, 'w+') do |file|
+          project_config.write(file)
+        end
+
+        logger.info("Project configuration updated!")
+      end
+    end
+  end
+end

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -106,4 +106,27 @@ describe Txgh::Hooks do
       }
     end
   end
+
+  describe '/project' do
+    let(:handler) { double(:handler) }
+    let(:tx_config_on_payload) { File.read(Pathname(File.dirname(__FILE__)).join('integration/config/tx.config')) }
+
+    it 'creates a handler and executes it' do
+      expect(app).to(
+        receive(:transifex_project_handler_for) do |options|
+          expect(options[:project].name).to eq (project_name)
+          expect(options[:new_config]).to eq(tx_config_on_payload)
+          handler
+        end
+      )
+
+      expect(handler).to receive(:execute)
+
+      params = {
+        'project' => project_name
+      }
+
+      post '/project', project: project_name, new_config: tx_config_on_payload
+    end
+  end
 end

--- a/spec/handlers/transifex_project_hook_handler_spec.rb
+++ b/spec/handlers/transifex_project_hook_handler_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+require 'helpers/nil_logger'
+
+include Txgh
+include Txgh::Handlers
+
+describe TransifexProjectHookHandler do
+  include StandardTxghSetup
+
+  let(:new_config) do
+    <<-TX_CONFIG
+    [main]
+    host = https://www.transifex.com
+    lang_map =
+
+    [common]
+    file_filter = config/locales/<lang>.yml
+    source_lang = en
+    source_file = en.yml
+    type = YML
+    minimum_perc = 20
+
+    [extra]
+    file_filter = config/locales/extra/<lang>.yml
+    source_lang = en
+    source_file = en.yml
+    type = YML
+    minimum_perc = 20
+    TX_CONFIG
+  end
+
+  let!(:handler) do
+    TransifexProjectHookHandler.new(
+      project: transifex_project,
+      new_config: new_config,
+      logger: logger
+    )
+  end
+
+  it 'updates project configuration' do
+    parse_config = double
+    expect(Txgh::ParseConfig).to receive(:load).with(new_config).and_return(parse_config)
+    expect(parse_config).to receive(:write)
+
+    handler.execute
+  end
+end

--- a/spec/integration/config/tx.config.bkp
+++ b/spec/integration/config/tx.config.bkp
@@ -1,0 +1,10 @@
+[main]
+host = https://www.transifex.com
+lang_map =
+
+# Create one such section per resource
+[test-project-88.samplepo]
+file_filter = translations/<lang>/sample.po
+source_file = sample.po
+source_lang = en
+type = PO

--- a/spec/integration/payloads/transifex_project_new_configuration.config
+++ b/spec/integration/payloads/transifex_project_new_configuration.config
@@ -1,0 +1,17 @@
+
+[main]
+host = "https://www.transifex.com"
+lang_map = ""
+
+[test-project-88.samplepo]
+file_filter = "translations/<lang>/sample.po"
+source_file = "sample.po"
+source_lang = "en"
+type = "PO"
+
+[test-project-88.another_samplepo]
+file_filter = "translations/<lang>/another_sample.po"
+source_file = "another_sample.po"
+source_lang = "en"
+type = "PO"
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,8 @@ module StandardTxghSetup
       'api_username' => 'transifex_api_username',
       'api_password' => 'transifex_api_password',
       'push_translations_to' => repo_name,
-      'name' => project_name
+      'name' => project_name,
+      'tx_config' => "config/#{project_name}.config"
     }
   end
 


### PR DESCRIPTION
This adds a new `/hooks/project` that updates the configuration for the project with the slug included on the request